### PR TITLE
Changes code for "Name is required" message and update button

### DIFF
--- a/tests/inputFields.spec.ts
+++ b/tests/inputFields.spec.ts
@@ -25,7 +25,8 @@ test('change the name of the cat', async ({ page }) => {
     await page.getByRole('button', { name: 'Update' }).click()
 
     //6. Add the assertion that the first pet type in the list of types has a value "rabbit" 
-    await expect(page.locator('input[name=pettype_name]').first()).toHaveValue('rabbit')
+    const firstPetType = page.locator('input[name=pettype_name]').first()
+    await expect(firstPetType).toHaveValue('rabbit')
 
 
     //7. Click on "Edit" button for the same "rabbit" pet type
@@ -39,8 +40,7 @@ test('change the name of the cat', async ({ page }) => {
     await editPetTypeInputField.fill('cat')
     await page.getByRole('button', { name: 'Update' }).click()
 
-    //9. Add the assertion that the first pet type in the list of names has a value "cat" 
-    const firstPetType = page.locator('input[name=pettype_name]').first()
+    //9. Add the assertion that the first pet type in the list of names has a value "cat"
     await expect(firstPetType).toHaveValue('cat')
 })
 
@@ -79,8 +79,7 @@ test('Pet type name is required validation', async ({ page }) => {
     await editPetTypeInputField.clear()
 
     //5. Add the assertion for the "Name is required" message below the input field
-    const requiredNameInField = await page.locator('.help-block', { hasText: 'Name is required' }).textContent()
-    await expect(requiredNameInField).toContain('Name is required')
+    await expect(page.locator('.help-block')).toContainText('Name is required')
 
     //6. Click on "Update" button
     await page.getByRole('button', { name: 'Update' }).click()


### PR DESCRIPTION
1. I made changes in the part "Name is required" message locator from :
 const requiredNameInField = await page.locator('.help-block', { hasText: 'Name is required' }).textContent()
 await expect(requiredNameInField).toContain('Name is required')
to =>await expect(page.locator('.help-block')).toContainText('Name is required')
and I also used locator assertion.

2. I created in line 6 const petPetType, because I used it later in my code line 44.

Please take a look for these changes. 